### PR TITLE
更新 (查看 changelog.md)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 env:
-    version: 0.11.8
+    version: 0.11.9
     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
 
 name: bilibili jimaku filter publish sign

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,9 +2,9 @@
 
     "manifest_version": 2,
     "name": "bilibili jimaku filter",
-    "version": "0.11.8",
+    "version": "0.11.9",
   
-    "description": "bilibili jimaku filter by ericlam",
+    "description": "B站同傳彈幕過濾插件",
     "author": "Eric Lam",
     "developer": {
       "name": "Eric Lam",

--- a/assets/settings.html
+++ b/assets/settings.html
@@ -348,6 +348,11 @@
                             <label class="custom-control-label" for="hide-blacklist">隐藏添加到黑名单的按钮</label>
                         </div>
                         <div class="custom-control custom-checkbox">
+                            <input type="checkbox" class="custom-control-input" id="hide-setting-btn">
+                            <label class="custom-control-label" for="hide-setting-btn" aria-describedby="setting-help">隐藏设定按钮</label>
+                            <small id="setting-help">(一般情况下，你可透过点击浏览器扩展图标来进入设定界面。)</small>
+                        </div>
+                        <div class="custom-control custom-checkbox">
                             <input type="checkbox" class="custom-control-input" id="theme-to-normal">
                             <label class="custom-control-label" for="theme-to-normal">大海报房间新增返回正常房间按钮</label>
                         </div>

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,5 @@
 ## 更新
 
-- 新增 DD 监控式视窗
-
-![png](https://github.com/eric2788/bilibili-jimaku-filter/raw/web/assets/dd-monitor.png)
-
-- 虚拟主播过滤不再使用 ``vup.farkflame.ga`` 作为 API，而改用 B站的 API
-
-- 修復資料庫連接失敗後按下添加到黑名單會把記錄字幕功能關閉
+- 现在虚拟主播在非虚拟主播分区直播时仍能有效辨识（基于 ddcenter 所提供的API）
+- 获取先前的醒目留言记录将优先采用 B站API, 若失败再使用js方式获取 (B站API -> js方式)
+- 考虑到有大量使用者不知道如何进入设定界面，将默认新增设定按钮到界面(可到设定关闭)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bilibili-jimaku-filter",
-  "version": "0.11.8",
+  "version": "0.11.9",
   "description": "jimaku filter for bilibili",
   "main": "index.js",
   "scripts": {

--- a/src/settings.js
+++ b/src/settings.js
@@ -54,6 +54,7 @@ function getCurrentInput() {
     setting.enableStreamPopup = $('#enable-stream-popup').prop('checked')
     setting.useLegacy = $('#use-legacy-mode').prop('checked')
     setting.hideBlackList = $('#hide-blacklist').prop('checked')
+    setting.hideSettingBtn = $('#hide-setting-btn').prop('checked')
     setting.themeToNormal = $('#theme-to-normal').prop('checked')
     setting.useRemoteCDN = $('#use-remote-cdn').prop('checked')
 
@@ -198,6 +199,7 @@ function saveCurrentInput(setting) {
     $('#use-legacy-mode').prop('checked', setting.useLegacy)
 
     $('#hide-blacklist').prop('checked', setting.hideBlackList)
+    $('#hide-setting-btn').prop('checked', setting.hideSettingBtn)
 
     $('#theme-to-normal').prop('checked', setting.themeToNormal)
 

--- a/src/utils/messaging.js
+++ b/src/utils/messaging.js
@@ -16,10 +16,6 @@ export async function webRequest(url){
     return sendData({type: 'request', url})
 }
 
-export async function getBeforeSuperChat(){
-    return sendData({type: 'before-sc'})
-}
-
 export async function checkUpdate(){
     return sendData({type: 'check-update'})
 }
@@ -28,11 +24,9 @@ export async function openInspectWindow(roomId, title){
     return sendData({type: 'open-window', roomId, title})
 }
 
-/* use getStreamUrls instead
-export async function getStreamUrl(roomId){
-    return sendData({type: 'get-stream-url', roomId})
+export async function goToSetting(){
+    return sendData({type: 'go-settings'})
 }
-*/
 
 export async function getStreamUrls(roomId){
     return sendData({type: 'get-stream-urls', roomId})

--- a/src/utils/misc.js
+++ b/src/utils/misc.js
@@ -43,6 +43,7 @@ const defaultSettings = {
     filterLevel: 0,
     useLegacy: false,
     hideBlackList: false,
+    hideSettingBtn: false,
     themeToNormal: false,
     useRemoteCDN: false,
     developer: {


### PR DESCRIPTION
<ul>
    <li>现在虚拟主播在非虚拟主播分区直播时仍能有效辨识（基于 ddcenter 所提供的API）</li>
    <li>获取先前的醒目留言记录将优先采用 B站API, 若失败再使用js方式获取 (B站API -> js方式)</li>
    <li>考虑到有大量使用者不知道如何进入设定界面，将默认新增设定按钮到界面(可到设定关闭)</li>
</ul>